### PR TITLE
unicorn の設定を改善

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,17 +1,17 @@
-rails_root = File.expand_path('../../', __FILE__)
-# rails_env = ENV['RAILS_ENV'] || "development"
+rails_root = File.expand_path("../../", __FILE__)
+# rails_env = ENV["RAILS_ENV"] || "development"
 
-ENV['BUNDLE_GEMFILE'] = rails_root + "/Gemfile"
+ENV["BUNDLE_GEMFILE"] = "#{rails_root}/Gemfile"
 
 worker_processes 2
 working_directory rails_root
 timeout 30
 preload_app true
 
-stderr_path File.expand_path(rails_root + '/log/unicorn_stderr.log', __FILE__)
-stdout_path File.expand_path(rails_root + '/log/unicorn_stdout.log', __FILE__)
+stderr_path File.expand_path("#{rails_root}/log/unicorn_stderr.log", __FILE__)
+stdout_path File.expand_path("#{rails_root}/log/unicorn_stdout.log", __FILE__)
 
-pid File.expand_path(rails_root + '../../tmp/pids/unicorn.pid', __FILE__)
+pid File.expand_path("#{rails_root}/tmp/pids/unicorn.pid", __FILE__)
 
 before_fork do |server, worker|
   defined?(ActiveRecord::Base) and

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,26 +1,32 @@
-worker_processes Integer(ENV["WEB_CONCURRENCY"] || 4)
-timeout 15
+rails_root = File.expand_path('../../', __FILE__)
+# rails_env = ENV['RAILS_ENV'] || "development"
+
+ENV['BUNDLE_GEMFILE'] = rails_root + "/Gemfile"
+
+worker_processes 2
+working_directory rails_root
+timeout 30
 preload_app true
-pid "tmp/unicorn.pid"
+
+stderr_path File.expand_path(rails_root + '/log/unicorn_stderr.log', __FILE__)
+stdout_path File.expand_path(rails_root + '/log/unicorn_stdout.log', __FILE__)
+
+pid File.expand_path(rails_root + '../../tmp/pids/unicorn.pid', __FILE__)
 
 before_fork do |server, worker|
-  Signal.trap 'TERM' do
-    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
-    Process.kill 'QUIT', Process.pid
-  end
-
   defined?(ActiveRecord::Base) and
     ActiveRecord::Base.connection.disconnect!
+
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if old_pid != server.pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+    end
+  end
 end
 
 after_fork do |server, worker|
-  Signal.trap 'TERM' do
-    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
-  end
-
-  defined?(ActiveRecord::Base) and
-    ActiveRecord::Base.establish_connection
+  defined?(ActiveRecord::Base) and ActiveRecord::Base.establish_connection
 end
-
-stderr_path File.expand_path('log/unicorn.log', ENV['RAILS_ROOT'])
-stdout_path File.expand_path('log/unicorn.log', ENV['RAILS_ROOT'])


### PR DESCRIPTION
* 現在の設定だと unicorn を restart するたびに全員ログアウトされる (原因はよくわかってない)
* 以下のコマンドで graceful restart が可能らしいがそれも現在の設定では効かないので、以下のコマンドが正常に動作するように修正
```
sudo kill -USR2 `cat tmp/pids/unicorn.pid`
```
* 参考 : https://qiita.com/syou007/items/555062cc96dd0b08a610