### PR TITLE
スコア保存時にログイン確認を追加

### DIFF
--- a/app/frontend/components/Routes/NewScore/CreateControl/index.js
+++ b/app/frontend/components/Routes/NewScore/CreateControl/index.js
@@ -7,11 +7,18 @@ import * as path            from "../../../../utils/path"
 import * as utils           from "../../../../utils"
 
 class CreateControl extends Component {
-  constructor() {
-    super()
-    this.state = { loading: false }
+  constructor(props) {
+    super(props)
+    this.state = { loading: false, modal: false }
   }
   handleClick = () => {
+    if (!this.props.userId) {
+      this.setState({ modal: true })
+    } else {
+      this.createScore()
+    }
+  }
+  createScore = () => {
     const { userId, handleSetState, handleResetLocalStorage, history } = this.props
     this.setState({ loading: true })
     api.createScore(

--- a/app/frontend/components/Routes/NewScore/CreateControl/index.js
+++ b/app/frontend/components/Routes/NewScore/CreateControl/index.js
@@ -8,8 +8,8 @@ import * as path            from "../../../../utils/path"
 import * as utils           from "../../../../utils"
 
 class CreateControl extends Component {
-  constructor(props) {
-    super(props)
+  constructor() {
+    super()
     this.state = { loading: false, modal: false }
   }
   handleClick = () => {
@@ -88,9 +88,9 @@ class CreateControl extends Component {
           handleClick={this.createScore}
           hideModal={this.hideConfirmModal}
         >
-          現在あなたはログインしていません。<br />
-          ログインしていない状態で保存すると、あとから編集や削除は出来ません。<br />
-          保存しますか？
+          現在ログインしていません。<br />
+          ログインしていない状態で保存した場合、あとから編集や削除はできません。<br />
+          本当に保存しますか？
         </ModalCard>
       </div>
     )

--- a/app/frontend/components/Routes/NewScore/CreateControl/index.js
+++ b/app/frontend/components/Routes/NewScore/CreateControl/index.js
@@ -2,6 +2,7 @@ import React, { Component } from "react"
 import { withRouter }       from "react-router-dom"
 import StatusControl        from "../../../StatusControl"
 import TwitterTL            from "../../../commons/TwitterTL"
+import ModalCard            from "../../../commons/ModalCard"
 import * as api             from "../../../../api"
 import * as path            from "../../../../utils/path"
 import * as utils           from "../../../../utils"
@@ -20,7 +21,7 @@ class CreateControl extends Component {
   }
   createScore = () => {
     const { userId, handleSetState, handleResetLocalStorage, history } = this.props
-    this.setState({ loading: true })
+    this.setState({ loading: true, modal: false })
     api.createScore(
       this.props,
       (success) => {
@@ -39,54 +40,58 @@ class CreateControl extends Component {
       }
     )
   }
+  hideConfirmModal = () => this.setState({ modal: false })
   render() {
     const { userId, status, handleSetState, isValid } = this.props
-    const { loading } = this.state
+    const { loading, modal } = this.state
     const iconClass = loading ? "fa fa-circle-o-notch fa-spin" : "fa fa-save"
     const buttonLabel = userId ? "save" : "save & share"
     return (
-      <div className="score-footer">
-        <div className="has-status-control">
-          {userId && (
-            <StatusControl
-              status={status}
-              handleSetState={handleSetState}
-            />
-          )}
-          {userId && <br />}
-          <div className="save-control">
-            <button
-              className="button is-primary is-medium animate-button"
-              onClick={this.handleClick}
-              disabled={loading || !isValid}
-            >
-              <span className="icon">
-                <i className={iconClass} />
-              </span>
-              <span>{buttonLabel}</span>
-            </button>
+      <div>
+        <div className="score-footer">
+          <div className="has-status-control">
+            {userId && (
+              <StatusControl
+                status={status}
+                handleSetState={handleSetState}
+              />
+            )}
+            {userId && <br />}
+            <div className="save-control">
+              <button
+                className="button is-primary is-medium animate-button"
+                onClick={this.handleClick}
+                disabled={loading || !isValid}
+              >
+                <span className="icon">
+                  <i className={iconClass} />
+                </span>
+                <span>{buttonLabel}</span>
+              </button>
+            </div>
           </div>
+          {!userId && (
+            <div>
+              <hr style={{ margin: "3rem 0" }} />
+              <div className="box twitter-tl">
+                <TwitterTL />
+              </div>
+            </div>
+          )}
         </div>
 
-        {!userId && (
-          <div>
-            <div className="notification is-size-7">
-              <span className="icon">
-                <i className="fa fa-warning" />
-              </span>
-              ログインしていない場合、保存後のデータは編集できませんのでご注意ください。
-            </div>
-          </div>
-        )}
-
-        {!userId && (
-          <div>
-            <hr style={{ margin: "3rem 0" }} />
-            <div className="box twitter-tl">
-              <TwitterTL />
-            </div>
-          </div>
-        )}
+        <ModalCard
+          isActive={modal}
+          title="Confirm"
+          icon="info-circle"
+          hasButtons
+          handleClick={this.createScore}
+          hideModal={this.hideConfirmModal}
+        >
+          現在あなたはログインしていません。<br />
+          ログインしていない状態で保存すると、あとから編集や削除は出来ません。<br />
+          保存しますか？
+        </ModalCard>
       </div>
     )
   }

--- a/app/frontend/components/Routes/NewScore/RestoreModal/index.js
+++ b/app/frontend/components/Routes/NewScore/RestoreModal/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import classNames           from "classnames"
+import Modal                from "../../../commons/modal"
 
 export default class RestoreModal extends Component {
   handleClick = () => {
@@ -9,39 +9,20 @@ export default class RestoreModal extends Component {
     this.hideModal()
   }
   hideModal = () => this.props.handleResetLocalStorage()
-
   render() {
     const { restoreState } = this.props
-    const modalClass = classNames("modal", { "is-active": restoreState })
-
     return (
-      <div className={modalClass}>
-        <div className="modal-background" role="presentation" onClick={this.hideModal} />
-        <div className="modal-card">
-          <header className="modal-card-head">
-            <p className="modal-card-title">
-              <span className="icon">
-                <i className="fa fa-info-circle" />
-              </span>
-              <span>Restore ?</span>
-            </p>
-            <button className="delete" onClick={this.hideModal} />
-          </header>
-          <section className="modal-card-body">
-            前回作業したデータが残っています。<br />
-            復元しますか？
-          </section>
-          <footer className="modal-card-foot right">
-            <button className="button is-success" onClick={this.handleClick}>
-              Yes
-            </button>
-            <button className="button" onClick={this.hideModal}>
-              No
-            </button>
-          </footer>
-        </div>
-        <button className="modal-close is-large" onClick={this.hideModal} />
-      </div>
+      <Modal
+        isActive={restoreState}
+        title="Restore ?"
+        icon="info-circle"
+        hasButtons
+        handleClick={this.handleClick}
+        hideModal={this.hideModal}
+      >
+        前回作業したデータが残っています。<br />
+        復元しますか？
+      </Modal>
     )
   }
 }

--- a/app/frontend/components/Routes/NewScore/RestoreModal/index.js
+++ b/app/frontend/components/Routes/NewScore/RestoreModal/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import Modal                from "../../../commons/modal"
+import ModalCard            from "../../../commons/ModalCard"
 
 export default class RestoreModal extends Component {
   handleClick = () => {
@@ -12,7 +12,7 @@ export default class RestoreModal extends Component {
   render() {
     const { restoreState } = this.props
     return (
-      <Modal
+      <ModalCard
         isActive={restoreState}
         title="Restore ?"
         icon="info-circle"
@@ -22,7 +22,7 @@ export default class RestoreModal extends Component {
       >
         前回作業したデータが残っています。<br />
         復元しますか？
-      </Modal>
+      </ModalCard>
     )
   }
 }

--- a/app/frontend/components/Routes/NewScore/index.js
+++ b/app/frontend/components/Routes/NewScore/index.js
@@ -129,7 +129,7 @@ export default class NewScore extends Component {
           handleResetLocalStorage={this.handleResetLocalStorage}
         />
         <ShareModal
-          label="saved, and let's share!"
+          label="saved!"
           token={token}
           title={title}
           isActive={modal}

--- a/app/frontend/components/Routes/ShowScore/DestroyScoreModal/index.js
+++ b/app/frontend/components/Routes/ShowScore/DestroyScoreModal/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import classNames           from "classnames"
+import ModalCard            from "../../../commons/ModalCard"
 import * as api             from "../../../../api"
 import * as path            from "../../../../utils/path"
 
@@ -15,34 +15,19 @@ export default class DestroyScoreModal extends Component {
   hideModal = () => this.props.handleToggleDestroyModal()
   render() {
     const { active } = this.props
-    const modalClass = classNames("modal", { "is-active": active })
     return (
-      <div className={modalClass}>
-        <div className="modal-background" role="presentation" onClick={this.hideModal} />
-        <div className="modal-card">
-          <header className="modal-card-head">
-            <p className="modal-card-title">
-              <span className="icon">
-                <i className="fa fa-exclamation-triangle" />
-              </span>
-              <span>Caution</span>
-            </p>
-            <button className="delete" onClick={this.hideModal} />
-          </header>
-          <section className="modal-card-body">
-            本当にスコアを削除しますか？
-          </section>
-          <footer className="modal-card-foot right">
-            <button className="button is-danger" onClick={this.handleDestroyScore}>
-              Yes
-            </button>
-            <button className="button" onClick={this.hideModal}>
-              No
-            </button>
-          </footer>
-        </div>
-        <button className="modal-close is-large" onClick={this.hideModal} />
-      </div>
+      <ModalCard
+        isActive={active}
+        title="Caution"
+        icon="exclamation-triangle"
+        hasButtons
+        buttonColor="danger"
+        handleClick={this.handleDestroyScore}
+        hideModal={this.hideModal}
+      >
+        一度削除したスコアは復元できません。<br />
+        本当にスコアを削除しますか？
+      </ModalCard>
     )
   }
 }

--- a/app/frontend/components/Routes/User/DestroyUserModal/index.js
+++ b/app/frontend/components/Routes/User/DestroyUserModal/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import classNames           from "classnames"
+import ModalCard            from "../../../commons/ModalCard"
 import * as api             from "../../../../api"
 import * as path            from "../../../../utils/path"
 import { window }           from "../../../../utils/browser-dependencies"
@@ -15,39 +15,21 @@ export default class DestroyUserModal extends Component {
     )
   )
   hideModal = () => this.props.handleToggleDestroyModal()
-
   render() {
     const { active } = this.props
-    const modalClass = classNames("modal", { "is-active": active })
-
     return (
-      <div className={modalClass}>
-        <div className="modal-background" role="presentation" onClick={this.hideModal} />
-        <div className="modal-card">
-          <header className="modal-card-head">
-            <p className="modal-card-title">
-              <span className="icon">
-                <i className="fa fa-exclamation-triangle" />
-              </span>
-              <span>Caution</span>
-            </p>
-            <button className="delete" onClick={this.hideModal} />
-          </header>
-          <section className="modal-card-body">
-            ユーザを削除すると、そのユーザで登録されたスコアもすべて削除されます。<br />
-            本当にユーザを削除しますか？
-          </section>
-          <footer className="modal-card-foot right">
-            <button className="button is-danger" onClick={this.handleDestroyUser}>
-              Yes
-            </button>
-            <button className="button" onClick={this.hideModal}>
-              No
-            </button>
-          </footer>
-        </div>
-        <button className="modal-close is-large" onClick={this.hideModal} />
-      </div>
+      <ModalCard
+        isActive={active}
+        title="Caution"
+        icon="exclamation-triangle"
+        hasButtons
+        buttonColor="danger"
+        handleClick={this.handleDestroyUser}
+        hideModal={this.hideModal}
+      >
+        ユーザを削除すると、そのユーザで登録されたスコアもすべて削除されます。<br />
+        本当にユーザを削除しますか？
+      </ModalCard>
     )
   }
 }

--- a/app/frontend/components/Routes/User/EditUser/index.js
+++ b/app/frontend/components/Routes/User/EditUser/index.js
@@ -43,12 +43,13 @@ export default class EditUser extends Component {
   handleInputTwitter    = (e) => this.handleChangeWithValidate("twitter",    e.target.value)
   handleBlurName = (e) => {
     this.handleTouch("name")
-    if (e.target.value === this.props.user.name) return this.setState({ validName: true })
-    if (!e.target.value) return this.setState({ validName: false })
+    const name = e.target.value
+    if (name === this.props.user.name) return this.setState({ validName: true })
+    if (!name || !(/^[a-z0-9._-]*$/).test(name)) return this.setState({ validName: false })
 
     this.setState({ loading: true })
     return api.validUserName(
-      { name: e.target.value },
+      { name },
       () => this.setState({ loading: false, validName: true }),
       (error) => (
         this.setState({ loading: false, validName: false, errors: utils.setApiErrors(error.response.data) })

--- a/app/frontend/components/commons/ModalCard.js
+++ b/app/frontend/components/commons/ModalCard.js
@@ -1,10 +1,10 @@
 import React, { Component } from "react"
 import classNames           from "classnames"
 
-export default class Modal extends Component {
+export default class ModalCard extends Component {
   render() {
     const {
-      isActive, title, icon, children, hasButtons, yesButtonLabel, noButtonLabel, handleClick, hideModal
+      isActive, title, icon, children, hasButtons, buttonColor, yesButtonLabel, noButtonLabel, handleClick, hideModal
     } = this.props
     const modalClass = classNames("modal", { "is-active": isActive })
     const iconClass = classNames("fa", `fa-${icon}`)
@@ -12,21 +12,23 @@ export default class Modal extends Component {
       <div className={modalClass}>
         <div className="modal-background" role="presentation" onClick={hideModal} />
         <div className="modal-card">
-          <header className="modal-card-head">
-            <p className="modal-card-title">
-              <span className="icon">
-                <i className={iconClass} />
-              </span>
-              <span>{title}</span>
-            </p>
-            <button className="delete" onClick={hideModal} />
-          </header>
+          {title && (
+            <header className="modal-card-head">
+              <p className="modal-card-title">
+                <span className="icon">
+                  <i className={iconClass} />
+                </span>
+                <span>{title}</span>
+              </p>
+              <button className="delete" onClick={hideModal} />
+            </header>
+          )}
           <section className="modal-card-body">
             {children}
           </section>
           {hasButtons && (
             <footer className="modal-card-foot right">
-              <button className="button is-success" onClick={handleClick}>
+              <button className={classNames("button", `is-${buttonColor || "success"}`)} onClick={handleClick}>
                 {yesButtonLabel || "Yes"}
               </button>
               <button className="button" onClick={hideModal}>

--- a/app/frontend/components/commons/modal.js
+++ b/app/frontend/components/commons/modal.js
@@ -1,0 +1,42 @@
+import React, { Component } from "react"
+import classNames           from "classnames"
+
+export default class Modal extends Component {
+  render() {
+    const {
+      isActive, title, icon, children, hasButtons, yesButtonLabel, noButtonLabel, handleClick, hideModal
+    } = this.props
+    const modalClass = classNames("modal", { "is-active": isActive })
+    const iconClass = classNames("fa", `fa-${icon}`)
+    return (
+      <div className={modalClass}>
+        <div className="modal-background" role="presentation" onClick={hideModal} />
+        <div className="modal-card">
+          <header className="modal-card-head">
+            <p className="modal-card-title">
+              <span className="icon">
+                <i className={iconClass} />
+              </span>
+              <span>{title}</span>
+            </p>
+            <button className="delete" onClick={hideModal} />
+          </header>
+          <section className="modal-card-body">
+            {children}
+          </section>
+          {hasButtons && (
+            <footer className="modal-card-foot right">
+              <button className="button is-success" onClick={handleClick}>
+                {yesButtonLabel || "Yes"}
+              </button>
+              <button className="button" onClick={hideModal}>
+                {noButtonLabel || "No"}
+              </button>
+            </footer>
+          )}
+        </div>
+        <button className="modal-close is-large" onClick={hideModal} />
+      </div>
+    )
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
           name:        SecureRandom.urlsafe_base64(8),
           screen_name: auth[:info][:name],
           icon:        auth[:info][:image],
-          site:        auth[:info][:urls][:google],
+          site:        auth[:info][:urls]&.fetch(:google),
           email:       auth[:info][:email]
         }
       when "tumblr"


### PR DESCRIPTION
## スクリーンショット
![image](https://user-images.githubusercontent.com/16236972/35865797-d43d1c08-0b98-11e8-9529-ca2ce8c1b8d7.png)

## 改善
* ログインしていない場合のみ、保存時に確認モーダルを追加
* モーダルをコンポーネント化してリファクタリング

## 修正
* Google で認証した際に例外が発生する場合があったので修正
* ユーザIDの変更時に `/` 等を入れると例外が発生していたので修正