### PR TITLE
babel-preset-xxx を devDependencies から production 用に移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "dependencies": {
     "@rails/webpacker": "^3.0.2",
     "axios": "^0.17.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "chord-translator": "^0.1.0",
     "classnames": "^2.2.5",
     "draft-js": "^0.10.4",
@@ -24,8 +26,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^8.0.1",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
     "eslint": "^4.10.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.8.0",


### PR DESCRIPTION
## 修正
* Rails および webpacker のバージョンアップ以降、 `assets:precompile` でエラーが出ていた
```
> rails assets:precompile
yarn install v1.7.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "@rails/webpacker > postcss-cssnext@3.1.0" has unmet peer dependency "caniuse-lite@^1.0.30000697".
[4/4] 📃  Building fresh packages...
✨  Done in 4.90s.
Webpacker is installed 🎉 🍰
Using /Users/wakabayashita/Private/Dev/rechord/config/webpacker.yml file for setting up webpack paths
Compiling…
Compilation failed:

Hash: 50477b6ea6f725e2b755
Version: webpack 3.12.0
Time: 397ms
                             Asset      Size  Chunks             Chunk Names
   rechord-d45c401b4186aa9c5cc5.js   3.75 kB       0  [emitted]  rechord
                     manifest.json  60 bytes          [emitted]  
rechord-d45c401b4186aa9c5cc5.js.gz   1.06 kB          [emitted]  
   [0] ./app/frontend/packs/rechord.js 2.77 kB {0} [built] [failed] [1 error]

ERROR in ./app/frontend/packs/rechord.js
Module build failed: ReferenceError: [BABEL] /Users/wakabayashita/Private/Dev/rechord/app/frontend/packs/rechord.js: Unknown option: /Users/wakabayashita/Private/Dev/rechord/node_modules/react/index.js.Children. Check out http://babeljs.io/docs/usage/options/ for more information about options.

A common cause of this error is the presence of a configuration options object without the corresponding preset name. Example:

Invalid:
  `{ presets: [{option: value}] }`
Valid:
  `{ presets: [['presetName', {option: value}]] }`

For more detailed information on preset configuration, please see https://babeljs.io/docs/en/plugins#pluginpresets-options. (While processing preset: "/Users/wakabayashita/Private/Dev/rechord/node_modules/react/index.js")
    at Logger.error (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/logger.js:41:11)
    at OptionManager.mergeOptions (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/options/option-manager.js:226:20)
    at /Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/options/option-manager.js:265:14
    at /Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/options/option-manager.js:323:22
    at Array.map (<anonymous>)
    at OptionManager.resolvePresets (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/options/option-manager.js:275:20)
    at OptionManager.mergePresets (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/options/option-manager.js:264:10)
    at OptionManager.mergeOptions (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/options/option-manager.js:249:14)
    at OptionManager.init (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-loader/lib/index.js:50:20)
    at /Users/wakabayashita/Private/Dev/rechord/node_modules/babel-loader/lib/fs-cache.js:118:18
    at ReadFileContext.callback (/Users/wakabayashita/Private/Dev/rechord/node_modules/babel-loader/lib/fs-cache.js:31:21)
```
* precompile の時に `babel-preset-react` が無いがためのエラー
    * node_modules/ にも確かになかった
* devDependencies から production 用に移動することで一旦解決したが、暫定対応